### PR TITLE
Hide scripts for legacy TweetDeck no longer usable so far

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,6 @@ Open workspace in the browser after signing in, not in desktop app
 
 Alert when you reload/close Slack with a new draft
 
-### [TweetDeck - Auto save draft](https://github.com/mkobayashime/userscripts/raw/main/dist/tweetdeck-auto-save-draft.user.js)
-
-Auto save composing tweet and restore it with Alt+P shortcut
-
-### [TweetDeck - No unintended reloads](https://github.com/mkobayashime/userscripts/raw/main/dist/tweetdeck-no-unintended-reload.user.js)
-
-Alert when you reload/close TweetDeck with a composing tweet
-
 ### [TweetDeck Preview - Shortcuts](https://github.com/mkobayashime/userscripts/raw/main/dist/tweetdeck-shortcuts.user.js)
 
 Refined shortcuts in the new (preview) version of TweetDeck

--- a/bin/docgen.ts
+++ b/bin/docgen.ts
@@ -89,17 +89,21 @@ const getFilesProperties = async ({
   kind: FileKind;
 }): Promise<FileProperties[]> => {
   if (kind === "script") {
-    return files.map((file) => {
+    return files.flatMap((file) => {
       const scriptMeta = meta[path.basename(file, ".user.ts")];
       if (!scriptMeta) {
         throw new Error(`Meta not found for userscript: ${file}`);
       }
 
-      return {
-        filename: path.basename(file),
-        title: scriptMeta.name,
-        description: scriptMeta.description,
-      };
+      if (scriptMeta.docgenIgnore) return [];
+
+      return [
+        {
+          filename: path.basename(file),
+          title: scriptMeta.name,
+          description: scriptMeta.description,
+        },
+      ];
     });
   }
 

--- a/src/userscripts/meta/index.ts
+++ b/src/userscripts/meta/index.ts
@@ -15,6 +15,7 @@ export type UserScriptMeta = {
     | "document-idle"
     | "context-menu";
   grant?: string;
+  docgenIgnore?: boolean;
 };
 
 export const meta: { [name: string]: UserScriptMeta | undefined } = {

--- a/src/userscripts/meta/index.ts
+++ b/src/userscripts/meta/index.ts
@@ -185,6 +185,7 @@ export const meta: { [name: string]: UserScriptMeta | undefined } = {
   },
   "tweetdeck-auto-save-draft": {
     description: "Auto save composing tweet and restore it with Alt+P shortcut",
+    docgenIgnore: true,
     icon: "https://www.google.com/s2/favicons?domain=tweetdeck.twitter.com",
     match: "https://tweetdeck.twitter.com/",
     name: "TweetDeck - Auto save draft",
@@ -195,6 +196,7 @@ export const meta: { [name: string]: UserScriptMeta | undefined } = {
     description: "Alert when you reload/close TweetDeck with a composing tweet",
     descriptionJp:
       "書きかけのツイートがある状態で TweetDeck をリロードしたり閉じてしまうのを防ぎます",
+    docgenIgnore: true,
     icon: "https://www.google.com/s2/favicons?domain=tweetdeck.twitter.com",
     match: "https://tweetdeck.twitter.com/",
     name: "TweetDeck - No unintended reloads",


### PR DESCRIPTION
- Ensure userscripts can be docgen-ignored
- Hide scripts for legacy TweetDeck no longer usable so far

- [ ] Bumped up the version if there are changes in the scripts/styles
