### PR TITLE
Add `rakuten-humanized`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Redirect Japanese pages in MDN to corresponding English pages
 
 Ctrl+Enter in "Save from site"
 
+### [Rakuten Humanized](https://github.com/mkobayashime/userscripts/raw/main/dist/rakuten-humanized.user.js)
+
+楽天の商品ページを人間にも使える程度にマシにします
+
 ### [Scrapbox - Clear Watch List](https://github.com/mkobayashime/userscripts/raw/main/dist/scrapbox-clear-watch-list.user.js)
 
 Scrapbox の Watch List を自動的に全削除します

--- a/dist/rakuten-humanized.user.js
+++ b/dist/rakuten-humanized.user.js
@@ -1,0 +1,25 @@
+// ==UserScript==
+// @name         Rakuten Humanized
+// @namespace    mkobayashime
+// @version      1.0.0
+// @description  楽天の商品ページを人間にも使える程度にマシにします
+// @icon         https://www.google.com/s2/favicons?domain=rakuten.co.jp
+// @author       mkobayashime
+// @homepage     https://github.com/mkobayashime/userscripts
+// @homepageURL  https://github.com/mkobayashime/userscripts
+// @match        https://item.rakuten.co.jp/*
+// @run-at       document-end
+// @updateURL    https://github.com/mkobayashime/userscripts/raw/main/dist/rakuten-humanized.user.js
+// @downloadURL  https://github.com/mkobayashime/userscripts/raw/main/dist/rakuten-humanized.user.js
+// ==/UserScript==
+
+// src/userscripts/rakuten-humanized/index.user.ts
+void (() => {
+  const itemNameArea = document.querySelector("#item-name-area");
+  if (!itemNameArea) return;
+  const table = itemNameArea.closest("table:has(#item-name-area)");
+  if (!table) return;
+  const prevSibling = table.previousElementSibling;
+  if (!prevSibling) return;
+  prevSibling.before(table);
+})();

--- a/src/userscripts/rakuten-humanized/index.user.ts
+++ b/src/userscripts/rakuten-humanized/index.user.ts
@@ -1,0 +1,22 @@
+import { defineUserScript } from "bundlemonkey";
+
+export default defineUserScript({
+  name: "Rakuten Humanized",
+  version: "1.0.0",
+  description: "楽天の商品ページを人間にも使える程度にマシにします",
+  match: ["https://item.rakuten.co.jp/*"],
+  runAt: "document-end",
+  icon: "https://www.google.com/s2/favicons?domain=rakuten.co.jp",
+  main: () => {
+    const itemNameArea = document.querySelector("#item-name-area");
+    if (!itemNameArea) return;
+
+    const table = itemNameArea.closest("table:has(#item-name-area)");
+    if (!table) return;
+
+    const prevSibling = table.previousElementSibling;
+    if (!prevSibling) return;
+
+    prevSibling.before(table);
+  },
+});


### PR DESCRIPTION
## Summary
- Add a new userscript `rakuten-humanized` for `item.rakuten.co.jp` that moves the item name table above its preceding sibling element, to make the layout more usable.

- [x] Bumped up the version if there are changes in the scripts/styles